### PR TITLE
Memory usage optimisations

### DIFF
--- a/lib/Sabre/DAV/ObjectTree.php
+++ b/lib/Sabre/DAV/ObjectTree.php
@@ -13,6 +13,8 @@ namespace Sabre\DAV;
  */
 class ObjectTree extends Tree {
 
+    const MAX_CACHE_SIZE = 1000;
+
     /**
      * The root node
      *
@@ -73,7 +75,9 @@ class ObjectTree extends Tree {
 
         }
 
-        $this->cache[$path] = $node;
+        if (count($this->cache) < self::MAX_CACHE_SIZE) {
+            $this->cache[$path] = $node;
+        }
         return $node;
 
     }
@@ -116,9 +120,11 @@ class ObjectTree extends Tree {
         $node = $this->getNodeForPath($path);
         $children = $node->getChildren();
         foreach($children as $child) {
-
-            $this->cache[trim($path,'/') . '/' . $child->getName()] = $child;
-
+            if (count($this->cache) < self::MAX_CACHE_SIZE) {
+                $this->cache[trim($path,'/') . '/' . $child->getName()] = $child;
+            } else {
+                break;
+            }
         }
         return $children;
 

--- a/lib/Sabre/DAV/Server.php
+++ b/lib/Sabre/DAV/Server.php
@@ -2167,7 +2167,7 @@ class Server {
 
         }
 
-        $this->tempOutputFile = tempnam("/tmp", "sabreMultiStatus");
+        $this->tempOutputFile = tempnam(sys_get_temp_dir(), "sabreMultiStatus");
         $dom->save($this->tempOutputFile);
         $fp = fopen($this->tempOutputFile, 'r+');
         return $fp;


### PR DESCRIPTION
Ok, i've created branch `bigcommerce-labs/sabre-dav:1.8-bigcommerce` so I can create proper pull request (we had only a tag before).
- `Server::generateMultiStatus()` - support Iterator as `$fileProperties` and also support objects as items of `$fileProperties`
- `Server::getNodesForPath()` - don't iterate over collection of children, return Iterator instead
- `ObjectTree` class - limit size of a cache

This PR is required for BIG-4045.

Once this gets merged, i'll tag it as `1.8.7.3`
