### PR TITLE
Return parent node in `getNodesForPath`

### DIFF
--- a/lib/Sabre/DAV/Server.php
+++ b/lib/Sabre/DAV/Server.php
@@ -1517,13 +1517,18 @@ class Server {
 
         $parentNode = $this->tree->getNodeForPath($path);
 
-        $nodes = array(
+        $parent = array(
             $path => $parentNode
         );
         if ($getChildren && $parentNode instanceof ICollection) {
-            $nodes = $this->tree->getChildren($path);
+            $children = $this->tree->getChildren($path);
+            $childrenIterator = ($children instanceof \Iterator) ? $children : new \ArrayIterator($children);
+            $nodes = new \AppendIterator();
+            $nodes->append(new \ArrayIterator($parent));
+            $nodes->append($childrenIterator);
+            return $nodes;
         }
-        return $nodes;
+        return $parent;
     }
 
     /**


### PR DESCRIPTION
Issue we're solving: Windows native WebDAV client doesn't show first file/directory in the directory listing.

Reason: first item in XML response for PROPFIND should be **current directory**.

I broke this rule previously here: https://github.com/bigcommerce-labs/sabre-dav/compare/1.8.7-alpha...1.8.7.3#diff-0a43e41da8e000bb77a423ebd27b6ba5L1514 by overriding `$nodes` variable in `lib/Sabre/DAV/Server.php:1524`

Now I remember that I did this and unfortunately forgot to fix it as everything was working fine in CyberDuck and cadaver and litmus tests were passing :-(

Now, if we're getting children by `getChildren` method, instead of returning only children, it returns **parent and children** inside of `AppendIterator`.

I'm also planning to write a blogpost / page on confluence as by this i've learnt about quite important differences in various clients & that litmus tests are not strict enough guarantee functionality across these clients.
