### PR TITLE
Apply support for large PROPFINDS to 3.2.2

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1645,42 +1645,43 @@ class Server extends EventEmitter implements LoggerAwareInterface {
 
 
     /**
-     * Generates a WebDAV propfind response body based on a list of nodes.
+     * Returns a callback generating a WebDAV propfind response body based on a list of nodes.
      *
      * If 'strip404s' is set to true, all 404 responses will be removed.
      *
      * @param array|\Traversable $fileProperties The list with nodes
      * @param bool $strip404s
-     * @return string
+     * @return callable
      */
     function generateMultiStatus($fileProperties, $strip404s = false) {
 
         $w = $this->xml->getWriter();
-        $w->openMemory();
-        $w->contextUri = $this->baseUri;
-        $w->startDocument();
+        return function() use ($fileProperties, $strip404s, $w) {
+            $w->openUri('php://output');
+            $w->contextUri = $this->baseUri;
+            $w->startDocument();
 
-        $w->startElement('{DAV:}multistatus');
+            $w->startElement('{DAV:}multistatus');
 
-        foreach ($fileProperties as $entry) {
-
-            $href = $entry['href'];
-            unset($entry['href']);
-            if ($strip404s) {
-                unset($entry[404]);
+            foreach ($fileProperties as $entry) {
+                $href = $entry['href'];
+                unset($entry['href']);
+                if ($strip404s) {
+                    unset($entry[404]);
+                }
+                $response = new Xml\Element\Response(
+                    ltrim($href, '/'),
+                    $entry
+                );
+                $w->write([
+                    'name'  => '{DAV:}response',
+                    'value' => $response
+                ]);
             }
-            $response = new Xml\Element\Response(
-                ltrim($href, '/'),
-                $entry
-            );
-            $w->write([
-                'name'  => '{DAV:}response',
-                'value' => $response
-            ]);
-        }
-        $w->endElement();
-
-        return $w->outputMemory();
+            $w->endElement();
+            $w->endDocument();
+            $w->flush();
+        };
 
     }
 

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
@@ -80,11 +80,13 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
+
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
@@ -71,11 +71,13 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
+
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/ExpandEventsDoubleEventsTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDoubleEventsTest.php
@@ -82,11 +82,13 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
+
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
@@ -93,11 +93,13 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
+
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 
@@ -141,11 +143,13 @@ END:VCALENDAR
 
         $this->assertEquals(207, $response->getStatus());
 
+        $bodyAsString = $response->getBodyAsString();
+
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 
@@ -178,11 +182,13 @@ END:VCALENDAR
 
         $this->assertEquals(200, $response->getStatus());
 
+        $bodyAsString = $response->getBodyAsString();
+
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
+++ b/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
@@ -75,7 +75,7 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
-        $this->assertTrue(strpos($response->body, 'BEGIN:VCALENDAR') !== false);
+        $this->assertTrue(strpos($response->getBodyAsString(), 'BEGIN:VCALENDAR') !== false);
 
     }
 

--- a/tests/Sabre/CalDAV/Issue203Test.php
+++ b/tests/Sabre/CalDAV/Issue203Test.php
@@ -84,11 +84,13 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
+
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/Issue205Test.php
+++ b/tests/Sabre/CalDAV/Issue205Test.php
@@ -79,14 +79,15 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
-        $this->assertFalse(strpos($response->body, '<s:exception>Exception</s:exception>'), 'Exception occurred: ' . $response->body);
-        $this->assertFalse(strpos($response->body, 'Unknown or bad format'), 'DateTime unknown format Exception: ' . $response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertFalse(strpos($bodyAsString, '<s:exception>Exception</s:exception>'), 'Exception occurred: ' . $bodyAsString);
+        $this->assertFalse(strpos($bodyAsString, 'Unknown or bad format'), 'DateTime unknown format Exception: ' . $bodyAsString);
 
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/Issue211Test.php
+++ b/tests/Sabre/CalDAV/Issue211Test.php
@@ -83,7 +83,7 @@ END:VCALENDAR
 
         // if this assert is reached, the endless loop is gone
         // There should be no matching events
-        $this->assertFalse(strpos('BEGIN:VEVENT', $response->body));
+        $this->assertFalse(strpos('BEGIN:VEVENT', $response->getBodyAsString()));
 
     }
 }

--- a/tests/Sabre/CalDAV/Issue220Test.php
+++ b/tests/Sabre/CalDAV/Issue220Test.php
@@ -91,9 +91,11 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
-        $this->assertFalse(strpos($response->body, '<s:exception>PHPUnit_Framework_Error_Warning</s:exception>'), 'Error Warning occurred: ' . $response->body);
-        $this->assertFalse(strpos($response->body, 'Invalid argument supplied for foreach()'), 'Invalid argument supplied for foreach(): ' . $response->body);
+        $body = $response->getBodyAsString();
 
-        $this->assertEquals(207, $response->status);
+        $this->assertFalse(strpos($body, '<s:exception>PHPUnit_Framework_Error_Warning</s:exception>'), 'Error Warning occurred: ' . $body);
+        $this->assertFalse(strpos($body, 'Invalid argument supplied for foreach()'), 'Invalid argument supplied for foreach(): ' . $body);
+
+        $this->assertEquals(207, $response->getStatus());
     }
 }

--- a/tests/Sabre/CalDAV/Issue228Test.php
+++ b/tests/Sabre/CalDAV/Issue228Test.php
@@ -73,7 +73,7 @@ END:VCALENDAR
         $response = $this->request($request);
 
         // We must check if absolutely nothing was returned from this query.
-        $this->assertFalse(strpos($response->body, 'BEGIN:VCALENDAR'));
+        $this->assertFalse(strpos($response->getBodyAsString(), 'BEGIN:VCALENDAR'));
 
     }
 }

--- a/tests/Sabre/CalDAV/JCalTransformTest.php
+++ b/tests/Sabre/CalDAV/JCalTransformTest.php
@@ -78,10 +78,12 @@ XML;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatus(), 'Full rsponse: ' . $response->getBodyAsString());
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->getStatus(), 'Full rsponse: ' . $body);
 
         $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
+            $body
         );
 
         $responses = $multiStatus->getResponses();
@@ -131,10 +133,12 @@ XML;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatus(), "Invalid response code. Full body: " . $response->getBodyAsString());
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->getStatus(), "Invalid response code. Full body: " . $body);
 
         $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
+            $body
         );
 
         $responses = $multiStatus->getResponses();
@@ -184,10 +188,13 @@ XML;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatus(), "Invalid response code. Full body: " . $response->getBodyAsString());
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->getStatus(), "Invalid response code. Full body: " . $body);
+
 
         $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
+            $body
         );
 
         $responses = $multiStatus->getResponses();

--- a/tests/Sabre/CalDAV/PluginTest.php
+++ b/tests/Sabre/CalDAV/PluginTest.php
@@ -18,6 +18,9 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
      * @var Plugin
      */
     protected $plugin;
+    /**
+     * @var HTTP\ResponseMock
+     */
     protected $response;
     /**
      * @var Backend\PDO
@@ -118,7 +121,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(501, $this->response->status, 'Incorrect status returned. Full response body:' . $this->response->body);
+        $this->assertEquals(501, $this->response->status, 'Incorrect status returned. Full response body:' . $this->response->getBodyAsString());
 
     }
 
@@ -334,7 +337,7 @@ END:VCALENDAR';
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: ' . $this->response->body);
+        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: ' . $this->response->getBodyAsString());
 
         $calendars = $this->caldavBackend->getCalendarsForUser('principals/user1');
         $this->assertEquals(3, count($calendars));
@@ -380,7 +383,7 @@ END:VCALENDAR';
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: ' . $this->response->body);
+        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: ' . $this->response->getBodyAsString());
 
         $calendars = $this->caldavBackend->getCalendarsForUser('principals/user1');
         $this->assertEquals(3, count($calendars));
@@ -613,7 +616,9 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+
+        $this->assertEquals(207, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $bodyAsString);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -639,7 +644,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
 
     }
 
@@ -671,7 +676,9 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $bodyAsString);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -697,7 +704,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
 
     }
 
@@ -733,7 +740,9 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $bodyAsString);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -759,7 +768,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
 
     }
 
@@ -793,7 +802,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -823,7 +832,9 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $bodyAsString);
 
         $expected = <<<XML
 <?xml version="1.0"?>
@@ -840,7 +851,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
 
     }
 
@@ -864,7 +875,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -896,7 +907,9 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $bodyAsString);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -922,7 +935,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
 
     }
 
@@ -951,7 +964,9 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $bodyAsString);
 
         $expected = <<<XML
 <?xml version="1.0"?>
@@ -968,7 +983,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
 
     }
 
@@ -1005,7 +1020,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -1032,7 +1047,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -1059,7 +1074,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 

--- a/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
+++ b/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
@@ -17,6 +17,11 @@ class FreeBusyRequestTest extends \PHPUnit_Framework_TestCase {
     protected $authPlugin;
     protected $caldavBackend;
 
+    /**
+     * @var HTTP\ResponseMock
+     */
+    protected $response;
+
     function setUp() {
 
         $caldavNS = '{' . CalDAV\Plugin::NS_CALDAV . '}';
@@ -307,13 +312,13 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                strpos($this->response->body, $string) !== false,
-                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->body
+                strpos($this->response->getBodyAsString(), $string) !== false,
+                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->getBodyAsString()
             );
         }
 
         $this->assertTrue(
-            strpos($this->response->body, 'FREEBUSY;FBTYPE=BUSY:20110101T080000Z/20110101T090000Z') == false,
+            strpos($this->response->getBodyAsString(), 'FREEBUSY;FBTYPE=BUSY:20110101T080000Z/20110101T090000Z') == false,
             'The response body did contain free busy info from a transparent calendar.'
         );
 
@@ -368,8 +373,8 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                strpos($this->response->body, $string) !== false,
-                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->body
+                strpos($this->response->getBodyAsString(), $string) !== false,
+                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->getBodyAsString()
             );
         }
 
@@ -423,8 +428,8 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                strpos($this->response->body, $string) !== false,
-                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->body
+                strpos($this->response->getBodyAsString(), $string) !== false,
+                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->getBodyAsString()
             );
         }
 
@@ -478,8 +483,8 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                strpos($this->response->body, $string) !== false,
-                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->body
+                strpos($this->response->getBodyAsString(), $string) !== false,
+                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->getBodyAsString()
             );
         }
 
@@ -552,8 +557,8 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                strpos($this->response->body, $string) !== false,
-                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->body
+                strpos($this->response->getBodyAsString(), $string) !== false,
+                'The response body did not contain: ' . $string . 'Full response: ' . $this->response->getBodyAsString()
             );
         }
 
@@ -600,8 +605,8 @@ ICS;
 
         foreach($strings as $string) {
             $this->assertTrue(
-                strpos($this->response->body, $string)!==false,
-                'The response body did not contain: ' . $string .'Full response: ' . $this->response->body
+                strpos($this->response->getBodyAsString(), $string)!==false,
+                'The response body did not contain: ' . $string .'Full response: ' . $this->response->getBodyAsString()
             );
         }
 

--- a/tests/Sabre/CardDAV/AddressBookQueryTest.php
+++ b/tests/Sabre/CardDAV/AddressBookQueryTest.php
@@ -37,12 +37,14 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $body);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($body);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -87,12 +89,14 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $body);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($body);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -132,12 +136,14 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $body);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($body);
 
         $this->assertEquals([], $result);
 
@@ -171,12 +177,14 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $body);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($body);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -214,12 +222,14 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $body);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($body);
 
         $vobjVersion = \Sabre\VObject\Version::VERSION;
 
@@ -259,12 +269,14 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $body);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($body);
 
         $vobjVersion = \Sabre\VObject\Version::VERSION;
 

--- a/tests/Sabre/CardDAV/MultiGetTest.php
+++ b/tests/Sabre/CardDAV/MultiGetTest.php
@@ -34,12 +34,14 @@ class MultiGetTest extends AbstractPluginTest {
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $body = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $body);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($body);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -77,12 +79,14 @@ class MultiGetTest extends AbstractPluginTest {
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $bodyAsString = $response->getBodyAsString();
+
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $prodId = "PRODID:-//Sabre//Sabre VObject " . \Sabre\VObject\Version::VERSION . "//EN";
 

--- a/tests/Sabre/DAV/AbstractServer.php
+++ b/tests/Sabre/DAV/AbstractServer.php
@@ -7,12 +7,12 @@ use Sabre\HTTP;
 abstract class AbstractServer extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\HTTP\ResponseMock
+     * @var \Sabre\HTTP\ResponseMock
      */
     protected $response;
     protected $request;
     /**
-     * @var Sabre\DAV\Server
+     * @var \Sabre\DAV\Server
      */
     protected $server;
     protected $tempDir = SABRE_TEMPDIR;

--- a/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
+++ b/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
@@ -28,7 +28,7 @@ class MapGetToPropFindTest extends DAV\AbstractServer {
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Incorrect status response received. Full response body: ' . $this->response->body);
+        $this->assertEquals(207, $this->response->status, 'Incorrect status response received. Full response body: ' . $this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -153,7 +153,7 @@ class PluginTest extends DAV\AbstractServer{
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(200, $this->response->getStatus(), 'Error: ' . $this->response->body);
+        $this->assertEquals(200, $this->response->getStatus(), 'Error: ' . $this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version'         => [DAV\Version::VERSION],
             'Content-Type'            => ['image/vnd.microsoft.icon'],
@@ -170,7 +170,7 @@ class PluginTest extends DAV\AbstractServer{
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(404, $this->response->getStatus(), 'Error: ' . $this->response->body);
+        $this->assertEquals(404, $this->response->getStatus(), 'Error: ' . $this->response->getBodyAsString());
 
     }
 
@@ -180,7 +180,7 @@ class PluginTest extends DAV\AbstractServer{
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(404, $this->response->getStatus(), 'Error: ' . $this->response->body);
+        $this->assertEquals(404, $this->response->getStatus(), 'Error: ' . $this->response->getBodyAsString());
 
     }
 }

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -56,7 +56,7 @@ class ServerTest extends DAV\AbstractServer{
          );
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
     }
 
@@ -75,7 +75,7 @@ class ServerTest extends DAV\AbstractServer{
         ], $this->response->getHeaders());
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals('Testing new file', file_get_contents($filename));
 
     }
@@ -109,7 +109,7 @@ class ServerTest extends DAV\AbstractServer{
         ], $this->response->getHeaders());
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertTrue(is_dir($this->tempDir . '/testcol'));
 
     }
@@ -124,7 +124,7 @@ class ServerTest extends DAV\AbstractServer{
         $this->assertEquals('0', $this->response->getHeader('Content-Length'));
 
         $this->assertEquals(204, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals('Testing updated file', file_get_contents($this->tempDir . '/test.txt'));
 
     }
@@ -141,7 +141,7 @@ class ServerTest extends DAV\AbstractServer{
         ], $this->response->getHeaders());
 
         $this->assertEquals(204, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertFalse(file_exists($this->tempDir . '/test.txt'));
 
     }
@@ -160,7 +160,7 @@ class ServerTest extends DAV\AbstractServer{
             'Content-Length'  => ['0'],
         ], $this->response->getHeaders());
         $this->assertEquals(204, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertFalse(file_exists($this->tempDir . '/testcol'));
 
     }
@@ -181,7 +181,7 @@ class ServerTest extends DAV\AbstractServer{
         ], $this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
     }
 
@@ -194,7 +194,7 @@ class ServerTest extends DAV\AbstractServer{
         $this->server->exec();
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
         $this->assertEquals([
             'Content-Length'  => ['0'],
@@ -231,7 +231,7 @@ class ServerTest extends DAV\AbstractServer{
         $this->server->exec();
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
         $this->assertEquals([
             'Content-Length'  => ['0'],

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -80,9 +80,9 @@ class PluginTest extends DAV\AbstractServer {
         $this->assertEquals('application/xml; charset=utf-8', $this->response->getHeader('Content-Type'));
         $this->assertTrue(preg_match('/^<opaquelocktoken:(.*)>$/', $this->response->getHeader('Lock-Token')) === 1, 'We did not get a valid Locktoken back (' . $this->response->getHeader('Lock-Token') . ')');
 
-        $this->assertEquals(200, $this->response->status, 'Got an incorrect status back. Response body: ' . $this->response->body);
+        $this->assertEquals(200, $this->response->status, 'Got an incorrect status back. Response body: ' . $this->response->getBodyAsString());
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -105,7 +105,7 @@ class PluginTest extends DAV\AbstractServer {
 
         foreach ($elements as $elem) {
             $data = $xml->xpath($elem);
-            $this->assertEquals(1, count($data), 'We expected 1 match for the xpath expression "' . $elem . '". ' . count($data) . ' were found. Full response body: ' . $this->response->body);
+            $this->assertEquals(1, count($data), 'We expected 1 match for the xpath expression "' . $elem . '". ' . count($data) . ' were found. Full response body: ' . $this->response->getBodyAsString());
         }
 
         $depth = $xml->xpath('/d:prop/d:lockdiscovery/d:activelock/d:depth');
@@ -141,7 +141,7 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals('application/xml; charset=utf-8', $this->response->getHeader('Content-Type'));
 
-        $this->assertEquals(423, $this->response->status, 'Full response: ' . $this->response->body);
+        $this->assertEquals(423, $this->response->status, 'Full response: ' . $this->response->getBodyAsString());
 
     }
 
@@ -276,7 +276,7 @@ class PluginTest extends DAV\AbstractServer {
             $this->response->getHeaders()
          );
 
-        $this->assertEquals(409, $this->response->status, 'Got an incorrect status code. Full response body: ' . $this->response->body);
+        $this->assertEquals(409, $this->response->status, 'Got an incorrect status code. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -340,7 +340,7 @@ class PluginTest extends DAV\AbstractServer {
         $this->server->httpResponse = new HTTP\ResponseMock();
         $this->server->invokeMethod($request, $this->server->httpResponse);
 
-        $this->assertEquals(204, $this->server->httpResponse->status, 'Got an incorrect status code. Full response body: ' . $this->response->body);
+        $this->assertEquals(204, $this->server->httpResponse->status, 'Got an incorrect status code. Full response body: ' . $this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
@@ -379,7 +379,7 @@ class PluginTest extends DAV\AbstractServer {
         $this->server->httpResponse = new HTTP\ResponseMock();
         $this->server->invokeMethod($request, $this->server->httpResponse);
 
-        $this->assertEquals(204, $this->server->httpResponse->status, 'Got an incorrect status code. Full response body: ' . $this->response->body);
+        $this->assertEquals(204, $this->server->httpResponse->status, 'Got an incorrect status code. Full response body: ' . $this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
@@ -716,7 +716,7 @@ class PluginTest extends DAV\AbstractServer {
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(201, $this->response->status, 'A valid lock-token was provided for the source, so this MOVE operation must succeed. Full response body: ' . $this->response->body);
+        $this->assertEquals(201, $this->response->status, 'A valid lock-token was provided for the source, so this MOVE operation must succeed. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -933,7 +933,7 @@ class PluginTest extends DAV\AbstractServer {
         $request->setBody('newbody');
         $this->server->httpRequest = $request;
         $this->server->exec();
-        $this->assertEquals(204, $this->response->status, 'Incorrect status received. Full response body:' . $this->response->body);
+        $this->assertEquals(204, $this->response->status, 'Incorrect status received. Full response body:' . $this->response->getBodyAsString());
 
     }
 

--- a/tests/Sabre/DAV/Mount/PluginTest.php
+++ b/tests/Sabre/DAV/Mount/PluginTest.php
@@ -27,7 +27,7 @@ class PluginTest extends DAV\AbstractServer {
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(501, $this->response->status, 'We expected GET to not be implemented for Directories. Response body: ' . $this->response->body);
+        $this->assertEquals(501, $this->response->status, 'We expected GET to not be implemented for Directories. Response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -46,8 +46,8 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(200, $this->response->status);
 
-        $xml = simplexml_load_string($this->response->body);
-        $this->assertInstanceOf('SimpleXMLElement', $xml, 'Response was not a valid xml document. The list of errors:' . print_r(libxml_get_errors(), true) . '. xml body: ' . $this->response->body . '. What type we got: ' . gettype($xml) . ' class, if object: ' . get_class($xml));
+        $xml = simplexml_load_string($this->response->getBodyAsString());
+        $this->assertInstanceOf('SimpleXMLElement', $xml, 'Response was not a valid xml document. The list of errors:' . print_r(libxml_get_errors(), true) . '. xml body: ' . $this->response->getBodyAsString() . '. What type we got: ' . gettype($xml) . ' class, if object: ' . get_class($xml));
 
         $xml->registerXPathNamespace('dm', 'http://purl.org/NET/webdav/mount');
         $url = $xml->xpath('//dm:url');

--- a/tests/Sabre/DAV/ServerMKCOLTest.php
+++ b/tests/Sabre/DAV/ServerMKCOLTest.php
@@ -24,7 +24,7 @@ class ServerMKCOLTest extends AbstractServer {
         ], $this->response->getHeaders());
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertTrue(is_dir($this->tempDir . '/testcol'));
 
     }
@@ -131,7 +131,7 @@ class ServerMKCOLTest extends AbstractServer {
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(400, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -163,7 +163,7 @@ class ServerMKCOLTest extends AbstractServer {
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(403, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(403, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -195,7 +195,7 @@ class ServerMKCOLTest extends AbstractServer {
             'Content-Length'  => ['0'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -229,7 +229,7 @@ class ServerMKCOLTest extends AbstractServer {
             'Content-Length'  => ['0'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -254,7 +254,7 @@ class ServerMKCOLTest extends AbstractServer {
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -279,7 +279,7 @@ class ServerMKCOLTest extends AbstractServer {
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -305,7 +305,7 @@ class ServerMKCOLTest extends AbstractServer {
             'Allow'           => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(405, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(405, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->getBodyAsString());
 
     }
 
@@ -332,14 +332,14 @@ class ServerMKCOLTest extends AbstractServer {
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+
+        $this->assertEquals(207, $this->response->status, 'Wrong statuscode received. Full response body: ' . $bodyAsString);
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
-
-        $responseBody = $this->response->getBodyAsString();
 
         $expected = <<<XML
 <?xml version="1.0"?>
@@ -358,7 +358,7 @@ XML;
 
         $this->assertXmlStringEqualsXmlString(
             $expected,
-            $responseBody
+            $bodyAsString
         );
 
     }

--- a/tests/Sabre/DAV/ServerPluginTest.php
+++ b/tests/Sabre/DAV/ServerPluginTest.php
@@ -62,7 +62,7 @@ class ServerPluginTest extends AbstractServer {
         ], $this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals('OPTIONS', $this->testPlugin->beforeMethod);
 
 

--- a/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
+++ b/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
@@ -48,7 +48,9 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
 
         $this->sendRequest("");
 
-        $this->assertEquals(207, $this->response->status, 'Incorrect status received. Full response body: ' . $this->response->getBodyAsString());
+        $bodyAsString = $this->response->getBodyAsString();
+
+        $this->assertEquals(207, $this->response->status, 'Incorrect status received. Full response body: ' . $bodyAsString);
 
         $this->assertEquals([
                 'X-Sabre-Version' => [Version::VERSION],
@@ -59,7 +61,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
             $this->response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $bodyAsString);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -120,7 +122,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -139,7 +141,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerPropsTest.php
+++ b/tests/Sabre/DAV/ServerPropsTest.php
@@ -56,7 +56,7 @@ class ServerPropsTest extends AbstractServer {
             $this->response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -82,7 +82,7 @@ class ServerPropsTest extends AbstractServer {
             $this->response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -105,7 +105,7 @@ class ServerPropsTest extends AbstractServer {
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -139,7 +139,7 @@ class ServerPropsTest extends AbstractServer {
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -158,7 +158,7 @@ class ServerPropsTest extends AbstractServer {
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -56,7 +56,7 @@ class ServerSimpleTest extends AbstractServer{
         ], $this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
     }
 
@@ -77,7 +77,7 @@ class ServerSimpleTest extends AbstractServer{
         ], $this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
     }
 
@@ -405,7 +405,7 @@ class ServerSimpleTest extends AbstractServer{
             $this->response->getHeaders()
          );
 
-        $this->assertEquals(415, $this->response->status, 'We got an incorrect status back. Full response body follows: ' . $this->response->body);
+        $this->assertEquals(415, $this->response->status, 'We got an incorrect status back. Full response body follows: ' . $this->response->getBodyAsString());
 
     }
 
@@ -429,7 +429,7 @@ class ServerSimpleTest extends AbstractServer{
             $this->response->getHeaders()
         );
 
-        $this->assertEquals(418, $this->response->status, 'We got an incorrect status back. Full response body follows: ' . $this->response->body);
+        $this->assertEquals(418, $this->response->status, 'We got an incorrect status back. Full response body follows: ' . $this->response->getBodyAsString());
 
     }
 

--- a/tests/Sabre/DAV/TemporaryFileFilterTest.php
+++ b/tests/Sabre/DAV/TemporaryFileFilterTest.php
@@ -21,7 +21,7 @@ class TemporaryFileFilterTest extends AbstractServer {
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals('0', $this->response->getHeader('Content-Length'));
 
@@ -37,7 +37,7 @@ class TemporaryFileFilterTest extends AbstractServer {
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
@@ -55,7 +55,7 @@ class TemporaryFileFilterTest extends AbstractServer {
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
@@ -81,7 +81,7 @@ class TemporaryFileFilterTest extends AbstractServer {
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
@@ -141,7 +141,7 @@ class TemporaryFileFilterTest extends AbstractServer {
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
@@ -151,12 +151,12 @@ class TemporaryFileFilterTest extends AbstractServer {
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(204, $this->response->status, "Incorrect status code received. Full body:\n" . $this->response->body);
+        $this->assertEquals(204, $this->response->status, "Incorrect status code received. Full body:\n" . $this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
     }
 
@@ -178,13 +178,15 @@ class TemporaryFileFilterTest extends AbstractServer {
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Incorrect status code returned. Body: ' . $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+
+        $this->assertEquals(207, $this->response->status, 'Incorrect status code returned. Body: ' . $bodyAsString);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
             'Content-Type' => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $bodyAsString);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 

--- a/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
+++ b/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
@@ -39,9 +39,11 @@ class SupportedReportSetTest extends DAV\AbstractServer {
 
         $this->sendPROPFIND($xml);
 
-        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: ' . $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: ' . $bodyAsString);
+
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $bodyAsString);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -80,9 +82,11 @@ class SupportedReportSetTest extends DAV\AbstractServer {
 
         $this->sendPROPFIND($xml);
 
-        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: ' . $this->response->body);
+        $body = $this->response->getBodyAsString();
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: ' . $body);
+
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $body);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $xml->registerXPathNamespace('x', 'http://www.rooftopsolutions.nl/testnamespace');
@@ -100,10 +104,10 @@ class SupportedReportSetTest extends DAV\AbstractServer {
         $this->assertEquals(2, count($data), 'We expected 2 \'d:report\' elements');
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:supported-report-set/d:supported-report/d:report/x:myreport');
-        $this->assertEquals(1, count($data), 'We expected 1 \'x:myreport\' element. Full body: ' . $this->response->body);
+        $this->assertEquals(1, count($data), 'We expected 1 \'x:myreport\' element. Full body: ' . $body);
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:supported-report-set/d:supported-report/d:report/d:anotherreport');
-        $this->assertEquals(1, count($data), 'We expected 1 \'d:anotherreport\' element. Full body: ' . $this->response->body);
+        $this->assertEquals(1, count($data), 'We expected 1 \'d:anotherreport\' element. Full body: ' . $body);
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:status');
         $this->assertEquals(1, count($data), 'We expected 1 \'d:status\' element');

--- a/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
@@ -142,7 +142,9 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $body = $server->httpResponse->getBodyAsString();
+
+        $this->assertEquals(207, $server->httpResponse->getStatus(), $body);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
@@ -161,7 +163,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:status'                  => 4,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
 
@@ -172,7 +174,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $body);
 
         }
 
@@ -215,7 +217,9 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $body = $server->httpResponse->getBodyAsString();
+
+        $this->assertEquals(207, $server->httpResponse->status, $body);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
@@ -234,7 +238,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:status'                  => 0,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
 
@@ -245,7 +249,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $body);
 
         }
 
@@ -287,7 +291,9 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $body = $server->httpResponse->getBodyAsString();
+
+        $this->assertEquals(207, $server->httpResponse->getStatus(), $body);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
@@ -306,7 +312,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:status'                  => 4,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
 
@@ -317,7 +323,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $body);
 
         }
 
@@ -352,7 +358,9 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $body = $server->httpResponse->getBodyAsString();
+
+        $this->assertEquals(207, $server->httpResponse->getStatus(), $body);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
@@ -365,7 +373,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response' => 0,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
 
@@ -376,7 +384,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $body);
 
         }
 


### PR DESCRIPTION
Takes Petr's changes from the 3.2.0.1 tag on this fork and (from this PR - https://github.com/sabre-io/dav/pull/898 - which wasn't accepted) and applies them to the latest tag 3.2.2.

3.2.0.1 also includes a commit to change the dependency of sabre-io/http to bigcommerce-labs/sabre-http. This isn't necessary to bring over as Petr's changes to _that_ component were accepted - https://github.com/sabre-io/http/pull/65.

Switching back to using the upstream for sabre-io/http will also bring us this fix - https://github.com/sabre-io/http/pull/73 - which should resolve - https://rpm.newrelic.com/accounts/44889/applications/4757985/traced_errors/4dca0f16-5188-11e8-b482-0242ac11000f_18714_21831 - which has the highest number of reported errors on production.



