### PR TITLE
FE-190 Use SATIS to publish a composer branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2.1
+
+orbs:
+  php: bigcommerce/internal-php@volatile
+
+workflows:
+  version: 2
+  full:
+    jobs:
+      - php/composer-github:
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
# What / Why?

Use [SATIS](https://github.com/composer/satis) to create a composer branch so it can be used to install dependencies without cloning each branch.

This step will run upon merging in master and create a `composer` branch containing a static version of a composer registry that can be used in `composer.json` to retrieve the available tags/branches.

@bigcommerce/husky @joec4i @TomA-R @cwalsh @PascalZajac @bigcommerce/data-engineers