### PR TITLE
Pin dependencies to BC deps, loosen psr/log versions and fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
         "ext-date" : "*",
         "ext-iconv" : "*",
         "lib-libxml" : ">=2.7.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 || ^2 || ^3"
     },
     "require-dev" : {
         "phpunit/phpunit" : "^9.6.22",
-        "monolog/monolog": "^1.18"
+        "monolog/monolog": "^1.18 || ^2 || ^3"
     },
     "suggest" : {
         "ext-curl" : "*",

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,15 @@
         }
     ],
     "repositories": [
-      { "type": "vcs", "url": "https://github.com/bigcommerce-labs/sabre-http", "replace": { "sabre/http": "*" } }
+        { "type": "git", "url": "https://github.com/bigcommerce/sabre-event", "replace": { "sabre/event": "*" } },
+        { "type": "git", "url": "https://github.com/bigcommerce/sabre-http", "replace": { "sabre/http": "*" } }
     ],
     "require": {
         "php": ">=8.1.0",
         "sabre/vobject": "^4.1.0",
-        "sabre/event" : ">=2.0.0, <4.0.0",
+        "sabre/event" : "^3.0.0.1",
         "sabre/xml"  : "^1.4.0",
-        "sabre/http" : "4.2.4.*",
+        "sabre/http" : "^4.2.4.4",
         "sabre/uri" : "^1.0.1",
         "ext-dom": "*",
         "ext-pcre": "*",

--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -318,7 +318,7 @@ class ICSExportPlugin extends DAV\ServerPlugin {
                     // VTIMEZONE is special, because we need to filter out the duplicates
                     case 'VTIMEZONE' :
                         // Naively just checking tzid.
-                        if (in_array((string)$child->TZID, $collectedTimezones)) continue;
+                        if (in_array((string)$child->TZID, $collectedTimezones)) break;
 
                         $timezones[] = clone $child;
                         $collectedTimezones[] = $child->TZID;

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -564,7 +564,7 @@ class Server extends EventEmitter implements LoggerAwareInterface {
      */
     function calculateUri($uri) {
 
-        if ($uri[0] != '/' && strpos($uri, '://')) {
+        if (is_string($uri) && $uri[0] != '/' && strpos($uri, '://')) {
 
             $uri = parse_url($uri, PHP_URL_PATH);
 

--- a/lib/DAV/Xml/Property/Href.php
+++ b/lib/DAV/Xml/Property/Href.php
@@ -58,7 +58,7 @@ class Href implements Element, HtmlOutput {
      */
     function getHref() {
 
-        return $this->hrefs[0];
+        return $this->hrefs[0] ?? null;
 
     }
 

--- a/lib/DAVACL/Plugin.php
+++ b/lib/DAVACL/Plugin.php
@@ -1400,7 +1400,7 @@ class Plugin extends DAV\ServerPlugin {
             foreach ($requestedProperties as $propertyName => $childRequestedProperties) {
 
                 // We're only traversing if sub-properties were requested
-                if (count($childRequestedProperties) === 0) continue;
+                if (is_null($childRequestedProperties) || count($childRequestedProperties) === 0) continue;
 
                 // We only have to do the expansion if the property was found
                 // and it contains an href element.

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -68,7 +68,7 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
             'share-access'                                            => \Sabre\DAV\Sharing\Plugin::ACCESS_SHAREDOWNER,
         ];
 
-        $this->assertInternalType('array', $calendars);
+        $this->assertIsArray($calendars);
         $this->assertEquals(1, count($calendars));
 
         foreach ($elementCheck as $name => $value) {
@@ -116,7 +116,7 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
             '{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp' => new CalDAV\Xml\Property\ScheduleCalendarTransp('transparent'),
         ];
 
-        $this->assertInternalType('array', $calendars);
+        $this->assertIsArray($calendars);
         $this->assertEquals(1, count($calendars));
 
         foreach ($elementCheck as $name => $value) {
@@ -130,9 +130,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testConstruct
-     * @expectedException \InvalidArgumentException
      */
     function testUpdateCalendarBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
 
@@ -196,9 +196,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testCreateCalendarAndFetch
-     * @expectedException \InvalidArgumentException
      */
     function testDeleteCalendarBadID() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
         $returnedId = $backend->createCalendar('principals/user2', 'somerandomid', [
@@ -212,9 +212,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testCreateCalendarAndFetch
-     * @expectedException \Sabre\DAV\Exception
      */
-    function testCreateCalendarIncorrectComponentSet() {;
+    function testCreateCalendarIncorrectComponentSet() {
+        $this->expectException(\Sabre\DAV\Exception::class);;
 
         $backend = new PDO($this->pdo);
 
@@ -290,7 +290,7 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
                 switch ($key) {
                     case 'lastmodified' :
-                        $this->assertInternalType('int', $actual);
+                        $this->assertIsInt($actual);
                         break;
                     case 'calendardata' :
                         if (is_resource($actual)) {
@@ -310,9 +310,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testGetMultipleObjects
-     * @expectedException \InvalidArgumentException
      */
     function testGetMultipleObjectsBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
         $backend->getMultipleCalendarObjects('bad-id', ['foo-bar']);
@@ -320,10 +320,10 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
      * @depends testCreateCalendarObject
      */
     function testCreateCalendarObjectNoComponent() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $backend = new PDO($this->pdo);
         $returnedId = $backend->createCalendar('principals/user2', 'somerandomid', []);
@@ -366,9 +366,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testCreateCalendarObject
-     * @expectedException \InvalidArgumentException
      */
     function testCreateCalendarObjectBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
         $returnedId = $backend->createCalendar('principals/user2', 'somerandomid', []);
@@ -548,9 +548,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testGetCalendarObjects
-     * @expectedException \InvalidArgumentException
      */
     function testGetCalendarObjectsBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
         $backend->getCalendarObjects('bad-id');
@@ -559,9 +559,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testGetCalendarObjects
-     * @expectedException \InvalidArgumentException
      */
     function testGetCalendarObjectBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
         $backend->getCalendarObject('bad-id', 'foo-bar');
@@ -616,9 +616,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testUpdateCalendarObject
-     * @expectedException \InvalidArgumentException
      */
     function testUpdateCalendarObjectBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
         $backend->updateCalendarObject('bad-id', 'object-id', 'objectdata');
@@ -644,9 +644,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testDeleteCalendarObject
-     * @expectedException \InvalidArgumentException
      */
     function testDeleteCalendarObjectBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
         $returnedId = $backend->createCalendar('principals/user2', 'somerandomid', []);
@@ -682,10 +682,10 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @depends testCalendarQueryNoResult
      */
     function testCalendarQueryBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $abstract = new PDO($this->pdo);
         $filters = [
@@ -901,9 +901,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testGetChanges
-     * @expectedException \InvalidArgumentException
      */
     function testGetChangesBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
         $id = $backend->createCalendar(
@@ -947,10 +947,8 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testCreateSubscriptionFail() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $props = [
         ];
@@ -1131,9 +1129,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testGetInvites
-     * @expectedException \InvalidArgumentException
      */
     function testGetInvitesBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
 
@@ -1284,9 +1282,9 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testUpdateInvites
-     * @expectedException \InvalidArgumentException
      */
     function testUpdateInvitesBadId() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $backend = new PDO($this->pdo);
         // Add a new invite
@@ -1342,7 +1340,7 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
                 ],
             ])
         ];
-        $this->assertEquals($expected, $result, null, 0.0, 10, true); // Last argument is $canonicalize = true, which allows us to compare, ignoring the order, because it's different between MySQL and Sqlite.
+        $this->assertEquals($expected, $result, '', 0.0, 10, true); // Last argument is $canonicalize = true, which allows us to compare, ignoring the order, because it's different between MySQL and Sqlite.
 
     }
 
@@ -1418,10 +1416,8 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\NotImplemented
-     */
     function testSetPublishStatus() {
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
 
         $backend = new PDO($this->pdo);
         $backend->setPublishStatus([1, 1], true);

--- a/tests/Sabre/CalDAV/Backend/SimplePDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/SimplePDOTest.php
@@ -77,7 +77,7 @@ SQL
             'uri' => 'somerandomid',
         ];
 
-        $this->assertInternalType('array', $calendars);
+        $this->assertIsArray($calendars);
         $this->assertEquals(1, count($calendars));
 
         foreach ($elementCheck as $name => $value) {

--- a/tests/Sabre/CalDAV/CalendarHomeNotificationsTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeNotificationsTest.php
@@ -16,10 +16,8 @@ class CalendarHomeNotificationsTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\NotFound
-     */
     function testGetChildNoSupport() {
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
         $backend = new Backend\Mock();
         $calendarHome = new CalendarHome($backend, ['uri' => 'principals/user']);

--- a/tests/Sabre/CalDAV/CalendarHomeSubscriptionsTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeSubscriptionsTest.php
@@ -61,10 +61,8 @@ class CalendarHomeSubscriptionsTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\InvalidResourceType
-     */
     function testNoSubscriptionSupport() {
+        $this->expectException(\Sabre\DAV\Exception\InvalidResourceType::class);
 
         $principal = [
             'uri' => 'principals/user1'

--- a/tests/Sabre/CalDAV/CalendarHomeTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeTest.php
@@ -33,10 +33,10 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotFound
      * @depends testSimple
      */
     function testGetChildNotFound() {
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
         $this->usercalendars->getChild('randomname');
 
@@ -94,30 +94,28 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $this->usercalendars->setACL([]);
 
     }
 
     /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
      * @depends testSimple
      */
     function testSetName() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $this->usercalendars->setName('bla');
 
     }
 
     /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
      * @depends testSimple
      */
     function testDelete() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $this->usercalendars->delete();
 
@@ -133,10 +131,10 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      * @depends testSimple
      */
     function testCreateFile() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->usercalendars->createFile('bla');
 
@@ -144,10 +142,10 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase {
 
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
      * @depends testSimple
      */
     function testCreateDirectory() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->usercalendars->createDirectory('bla');
 
@@ -170,10 +168,10 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\InvalidResourceType
      * @depends testSimple
      */
     function testCreateExtendedCollectionBadResourceType() {
+        $this->expectException(\Sabre\DAV\Exception\InvalidResourceType::class);
 
         $mkCol = new MkCol(
             ['{DAV:}collection', '{DAV:}blabla'],
@@ -184,10 +182,10 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\InvalidResourceType
      * @depends testSimple
      */
     function testCreateExtendedCollectionNotACalendar() {
+        $this->expectException(\Sabre\DAV\Exception\InvalidResourceType::class);
 
         $mkCol = new MkCol(
             ['{DAV:}collection'],
@@ -203,10 +201,8 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\NotImplemented
-     */
     function testShareReplyFail() {
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
 
         $this->usercalendars->shareReply('uri', DAV\Sharing\Plugin::INVITE_DECLINED, 'curi', '1');
 

--- a/tests/Sabre/CalDAV/CalendarObjectTest.php
+++ b/tests/Sabre/CalDAV/CalendarObjectTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\CalDAV;
 
+use InvalidArgumentException;
+
 require_once 'Sabre/CalDAV/TestUtil.php';
 
 class CalendarObjectTest extends \PHPUnit\Framework\TestCase {
@@ -38,17 +40,15 @@ class CalendarObjectTest extends \PHPUnit\Framework\TestCase {
         $children = $this->calendar->getChildren();
         $this->assertTrue($children[0] instanceof CalendarObject);
 
-        $this->assertInternalType('string', $children[0]->getName());
-        $this->assertInternalType('string', $children[0]->get());
-        $this->assertInternalType('string', $children[0]->getETag());
+        $this->assertIsString($children[0]->getName());
+        $this->assertIsString($children[0]->get());
+        $this->assertIsString($children[0]->getETag());
         $this->assertEquals('text/calendar; charset=utf-8', $children[0]->getContentType());
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testInvalidArg1() {
+        $this->expectException(InvalidArgumentException::class);
 
         $obj = new CalendarObject(
             new Backend\Mock([], []),
@@ -58,10 +58,8 @@ class CalendarObjectTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testInvalidArg2() {
+        $this->expectException(InvalidArgumentException::class);
 
         $obj = new CalendarObject(
             new Backend\Mock([], []),
@@ -145,7 +143,7 @@ class CalendarObjectTest extends \PHPUnit\Framework\TestCase {
         $obj = $children[0];
 
         $size = $obj->getSize();
-        $this->assertInternalType('int', $size);
+        $this->assertIsInt($size);
 
     }
 
@@ -233,10 +231,8 @@ class CalendarObjectTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $children = $this->calendar->getChildren();
         $this->assertTrue($children[0] instanceof CalendarObject);

--- a/tests/Sabre/CalDAV/CalendarTest.php
+++ b/tests/Sabre/CalDAV/CalendarTest.php
@@ -82,10 +82,10 @@ class CalendarTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotFound
      * @depends testSimple
      */
     function testGetChildNotFound() {
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
         $this->calendar->getChild('randomname');
 
@@ -116,19 +116,15 @@ class CalendarTest extends \PHPUnit\Framework\TestCase {
 
 
 
-    /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
-     */
     function testCreateDirectory() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->calendar->createDirectory('hello');
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
-     */
     function testSetName() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->calendar->setName('hello');
 
@@ -225,10 +221,8 @@ class CalendarTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $this->calendar->setACL([]);
 

--- a/tests/Sabre/CalDAV/FreeBusyReportTest.php
+++ b/tests/Sabre/CalDAV/FreeBusyReportTest.php
@@ -114,10 +114,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testFreeBusyReportNoTimeRange() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $reportXML = <<<XML
 <?xml version="1.0"?>
@@ -129,10 +127,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\NotImplemented
-     */
     function testFreeBusyReportWrongNode() {
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
 
         $request = HTTP\Sapi::createFromServerArray([
             'REQUEST_URI' => '/',
@@ -151,10 +147,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception
-     */
     function testFreeBusyReportNoACLPlugin() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $this->server = new DAV\Server();
         $this->plugin = new Plugin();

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -212,8 +212,8 @@ ICS
 
         $obj = VObject\Reader::read($response->getBody());
 
-        $this->assertEquals(0, count($obj->VTIMEZONE));
-        $this->assertEquals(0, count($obj->VEVENT));
+        $this->assertEquals(0, count($obj->VTIMEZONE ?? []));
+        $this->assertEquals(0, count($obj->VEVENT ?? []));
 
     }
 
@@ -237,8 +237,8 @@ ICS
 
         $obj = VObject\Reader::read($response->getBody());
 
-        $this->assertEquals(0, count($obj->VTIMEZONE));
-        $this->assertEquals(1, count($obj->VEVENT));
+        $this->assertEquals(0, count($obj->VTIMEZONE ?? []));
+        $this->assertEquals(1, count($obj->VEVENT ?? []));
 
     }
 
@@ -292,7 +292,7 @@ ICS
         $obj = VObject\Reader::read($response->body);
         $this->assertEquals(1, count($obj->VTIMEZONE));
         $this->assertEquals(1, count($obj->VEVENT));
-        $this->assertEquals(0, count($obj->VTODO));
+        $this->assertEquals(0, count($obj->VTODO ?? []));
 
     }
 
@@ -307,8 +307,8 @@ ICS
 
         $obj = VObject\Reader::read($response->body);
 
-        $this->assertEquals(0, count($obj->VTIMEZONE));
-        $this->assertEquals(0, count($obj->VEVENT));
+        $this->assertEquals(0, count($obj->VTIMEZONE ?? []));
+        $this->assertEquals(0, count($obj->VEVENT ?? []));
         $this->assertEquals(1, count($obj->VTODO));
 
     }

--- a/tests/Sabre/CalDAV/Notifications/CollectionTest.php
+++ b/tests/Sabre/CalDAV/Notifications/CollectionTest.php
@@ -66,10 +66,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $col = $this->getInstance();
         $col->setACL([]);

--- a/tests/Sabre/CalDAV/Notifications/NodeTest.php
+++ b/tests/Sabre/CalDAV/Notifications/NodeTest.php
@@ -77,10 +77,8 @@ class NodeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $node = $this->getInstance();
         $node->setACL([]);

--- a/tests/Sabre/CalDAV/PluginTest.php
+++ b/tests/Sabre/CalDAV/PluginTest.php
@@ -350,7 +350,7 @@ END:VCALENDAR';
            }
         }
 
-        $this->assertInternalType('array', $newCalendar);
+        $this->assertIsArray($newCalendar);
 
         $keys = [
             'uri'                                                             => 'NEWCALENDAR',
@@ -396,7 +396,7 @@ END:VCALENDAR';
            }
         }
 
-        $this->assertInternalType('array', $newCalendar);
+        $this->assertIsArray($newCalendar);
 
         $keys = [
             'uri'                                                             => 'NEWCALENDAR',

--- a/tests/Sabre/CalDAV/Principal/ProxyReadTest.php
+++ b/tests/Sabre/CalDAV/Principal/ProxyReadTest.php
@@ -39,20 +39,16 @@ class ProxyReadTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testDelete() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $i = $this->getInstance();
         $i->delete();
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testSetName() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $i = $this->getInstance();
         $i->setName('foo');

--- a/tests/Sabre/CalDAV/Principal/UserTest.php
+++ b/tests/Sabre/CalDAV/Principal/UserTest.php
@@ -24,20 +24,16 @@ class UserTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testCreateFile() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $u = $this->getInstance();
         $u->createFile('test');
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testCreateDirectory() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $u = $this->getInstance();
         $u->createDirectory('test');
@@ -60,20 +56,16 @@ class UserTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\NotFound
-     */
     function testGetChildNotFound() {
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
         $u = $this->getInstance();
         $child = $u->getChild('foo');
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\NotFound
-     */
     function testGetChildNotFound2() {
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
         $u = $this->getInstance();
         $child = $u->getChild('random');

--- a/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
+++ b/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
@@ -143,10 +143,8 @@ END:VCALENDAR',
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testNoItipMethod() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $this->server->httpRequest = new HTTP\Request(
             'POST',
@@ -166,10 +164,8 @@ ICS;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\NotImplemented
-     */
     function testNoVFreeBusy() {
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
 
         $this->server->httpRequest = new HTTP\Request(
             'POST',
@@ -190,10 +186,8 @@ ICS;
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testIncorrectOrganizer() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $this->server->httpRequest = new HTTP\Request(
             'POST',
@@ -216,10 +210,8 @@ ICS;
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testNoAttendees() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $this->server->httpRequest = new HTTP\Request(
             'POST',
@@ -241,10 +233,8 @@ ICS;
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testNoDTStart() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $this->server->httpRequest = new HTTP\Request(
             'POST',

--- a/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
+++ b/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
@@ -214,7 +214,7 @@ ICS;
 
         $expected = [];
         $this->assertEquals($expected, $result);
-        $this->assertEquals('1.0', $message->getScheduleStatus()[0]);
+        $this->assertEquals('1.0', $message->getScheduleStatus());
 
     }
 

--- a/tests/Sabre/CalDAV/Schedule/SchedulingObjectTest.php
+++ b/tests/Sabre/CalDAV/Schedule/SchedulingObjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CalDAV\Schedule;
 
+use InvalidArgumentException;
 use Sabre\CalDAV\Backend;
 
 class SchedulingObjectTest extends \PHPUnit\Framework\TestCase {
@@ -58,17 +59,15 @@ ICS;
         $children = $this->inbox->getChildren();
         $this->assertTrue($children[0] instanceof SchedulingObject);
 
-        $this->assertInternalType('string', $children[0]->getName());
-        $this->assertInternalType('string', $children[0]->get());
-        $this->assertInternalType('string', $children[0]->getETag());
+        $this->assertIsString($children[0]->getName());
+        $this->assertIsString($children[0]->get());
+        $this->assertIsString($children[0]->getETag());
         $this->assertEquals('text/calendar; charset=utf-8', $children[0]->getContentType());
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testInvalidArg1() {
+        $this->expectException(InvalidArgumentException::class);
 
         $obj = new SchedulingObject(
             new Backend\MockScheduling([], []),
@@ -78,10 +77,8 @@ ICS;
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testInvalidArg2() {
+        $this->expectException(InvalidArgumentException::class);
 
         $obj = new SchedulingObject(
             new Backend\MockScheduling([], []),
@@ -93,9 +90,9 @@ ICS;
 
     /**
      * @depends testSetup
-     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testPut() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $children = $this->inbox->getChildren();
         $this->assertTrue($children[0] instanceof SchedulingObject);
@@ -146,7 +143,7 @@ ICS;
         $obj = $children[0];
 
         $size = $obj->getSize();
-        $this->assertInternalType('int', $size);
+        $this->assertIsInt($size);
 
     }
 
@@ -224,10 +221,8 @@ ICS;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $children = $this->inbox->getChildren();
         $this->assertTrue($children[0] instanceof SchedulingObject);

--- a/tests/Sabre/CalDAV/SharingPluginTest.php
+++ b/tests/Sabre/CalDAV/SharingPluginTest.php
@@ -51,10 +51,8 @@ class SharingPluginTest extends \Sabre\DAVServerTest {
 
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     function testSetupWithoutCoreSharingPlugin() {
+        $this->expectException(\LogicException::class);
 
         $server = new DAV\Server();
         $server->addPlugin(
@@ -317,7 +315,7 @@ RRR;
         $request->setBody($xml);
 
         $response = $this->request($request);
-        $this->assertEquals(202, $response->status, $response->body);
+        $this->assertEquals(202, $response->status, $response->body ?? '');
 
     }
 
@@ -337,7 +335,7 @@ RRR;
         $request->setBody($xml);
 
         $response = $this->request($request);
-        $this->assertEquals(200, $response->status, $response->body);
+        $this->assertEquals(200, $response->status, $response->body ?? '');
 
     }
 

--- a/tests/Sabre/CalDAV/Subscriptions/SubscriptionTest.php
+++ b/tests/Sabre/CalDAV/Subscriptions/SubscriptionTest.php
@@ -83,10 +83,8 @@ class SubscriptionTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $sub = $this->getSub();
         $sub->setACL([]);
@@ -118,10 +116,8 @@ class SubscriptionTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     function testBadConstruct() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $caldavBackend = new \Sabre\CalDAV\Backend\MockSubscriptionSupport([], []);
         new Subscription($caldavBackend, []);

--- a/tests/Sabre/CalDAV/Xml/Notification/InviteReplyTest.php
+++ b/tests/Sabre/CalDAV/Xml/Notification/InviteReplyTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CalDAV\Xml\Notification;
 
+use InvalidArgumentException;
 use Sabre\DAV;
 use Sabre\Xml\Writer;
 
@@ -115,19 +116,15 @@ FOO
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testMissingArg() {
+        $this->expectException(InvalidArgumentException::class);
 
         new InviteReply([]);
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testUnknownArg() {
+        $this->expectException(InvalidArgumentException::class);
 
         new InviteReply([
             'foo-i-will-break' => true,

--- a/tests/Sabre/CalDAV/Xml/Notification/InviteTest.php
+++ b/tests/Sabre/CalDAV/Xml/Notification/InviteTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CalDAV\Xml\Notification;
 
+use InvalidArgumentException;
 use Sabre\CalDAV;
 use Sabre\DAV;
 use Sabre\Xml\Writer;
@@ -121,19 +122,15 @@ FOO
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testMissingArg() {
+        $this->expectException(InvalidArgumentException::class);
 
         new Invite([]);
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testUnknownArg() {
+        $this->expectException(InvalidArgumentException::class);
 
         new Invite([
             'foo-i-will-break' => true,

--- a/tests/Sabre/CalDAV/Xml/Property/ScheduleCalendarTranspTest.php
+++ b/tests/Sabre/CalDAV/Xml/Property/ScheduleCalendarTranspTest.php
@@ -25,10 +25,8 @@ class ScheduleCalendarTranspTest extends DAV\Xml\XmlTest {
 
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     function testBadValue() {
+        $this->expectException(\InvalidArgumentException::class);
 
         new ScheduleCalendarTransp('ahhh');
 

--- a/tests/Sabre/CalDAV/Xml/Property/SupportedCalendarComponentSetTest.php
+++ b/tests/Sabre/CalDAV/Xml/Property/SupportedCalendarComponentSetTest.php
@@ -78,10 +78,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\Xml\ParseException
-     */
     function testUnserializeEmpty() {
+        $this->expectException(\Sabre\Xml\ParseException::class);
 
         $cal = CalDAV\Plugin::NS_CALDAV;
         $cs = CalDAV\Plugin::NS_CALENDARSERVER;

--- a/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
+++ b/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
@@ -46,10 +46,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeNoFilter() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>
@@ -216,10 +214,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeDoubleTopCompFilter() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>
@@ -241,10 +237,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeMissingExpandEnd() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>
@@ -265,10 +259,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeExpandEndBeforeStart() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>
@@ -289,10 +281,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeTimeRangeOnVCALENDAR() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>
@@ -313,10 +303,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeTimeRangeEndBeforeStart() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>
@@ -339,10 +327,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeTimeRangePropEndBeforeStart() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>

--- a/tests/Sabre/CalDAV/Xml/Request/InviteReplyTest.php
+++ b/tests/Sabre/CalDAV/Xml/Request/InviteReplyTest.php
@@ -57,10 +57,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeNoHostUrl() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>

--- a/tests/Sabre/CardDAV/AddressBookHomeTest.php
+++ b/tests/Sabre/CardDAV/AddressBookHomeTest.php
@@ -28,19 +28,15 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
-     */
     function testSetName() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->s->setName('user2');
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
-     */
     function testDelete() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->s->delete();
 
@@ -52,19 +48,15 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
-     */
     function testCreateFile() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->s->createFile('bla');
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
-     */
     function testCreateDirectory() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->s->createDirectory('bla');
 
@@ -78,10 +70,8 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\NotFound
-     */
     function testGetChild404() {
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
         $this->s->getChild('book2');
 
@@ -113,10 +103,8 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\InvalidResourceType
-     */
     function testCreateExtendedCollectionInvalid() {
+        $this->expectException(\Sabre\DAV\Exception\InvalidResourceType::class);
 
         $resourceType = [
             '{DAV:}collection',
@@ -140,12 +128,10 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
-       $this->s->setACL([]);
+        $this->s->setACL([]);
 
     }
 

--- a/tests/Sabre/CardDAV/AddressBookTest.php
+++ b/tests/Sabre/CardDAV/AddressBookTest.php
@@ -43,10 +43,8 @@ class AddressBookTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\NotFound
-     */
     function testGetChildNotFound() {
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
         $card = $this->ab->getChild('card3');
 
@@ -62,10 +60,8 @@ class AddressBookTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
-     */
     function testCreateDirectory() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->ab->createDirectory('name');
 
@@ -89,10 +85,8 @@ class AddressBookTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
-     */
     function testSetName() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $this->ab->setName('foo');
 
@@ -139,12 +133,10 @@ class AddressBookTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
-       $this->ab->setACL([]);
+        $this->ab->setACL([]);
 
     }
 

--- a/tests/Sabre/CardDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CardDAV/Backend/AbstractPDOTest.php
@@ -148,10 +148,8 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testCreateAddressBookUnsupportedProp() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $this->backend->createAddressBook('principals/user1', 'book2', [
             '{DAV:}foo' => 'bar',
@@ -286,7 +284,7 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase {
 
                 switch ($k) {
                     case 'lastmodified' :
-                        $this->assertInternalType('int', $actual);
+                        $this->assertIsInt($actual);
                         break;
                     case 'carddata' :
                         if (is_resource($actual)) {

--- a/tests/Sabre/CardDAV/CardTest.php
+++ b/tests/Sabre/CardDAV/CardTest.php
@@ -190,10 +190,8 @@ class CardTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testSetACL() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
        $this->card->setACL([]);
 

--- a/tests/Sabre/CardDAV/VCFExportTest.php
+++ b/tests/Sabre/CardDAV/VCFExportTest.php
@@ -85,7 +85,7 @@ END:VCARD
         $actions = '';
         $addressbook = new AddressBook($this->carddavBackend, []);
         $this->server->emit('browserButtonActions', ['/foo', $addressbook, &$actions]);
-        $this->assertContains('/foo?export', $actions);
+        $this->assertStringContainsString('/foo?export', $actions);
 
     }
 

--- a/tests/Sabre/CardDAV/ValidateFilterTest.php
+++ b/tests/Sabre/CardDAV/ValidateFilterTest.php
@@ -14,7 +14,7 @@ class ValidateFilterTest extends AbstractPluginTest {
      * @param string|null $message
      * @dataProvider data
      */
-    function testFilter($input, $filters, $test, $result, $message = null) {
+    function testFilter($input, $filters, $test, $result, $message = '') {
 
         if ($result) {
             $this->assertTrue($this->plugin->validateFilters($input, $filters, $test), $message);

--- a/tests/Sabre/CardDAV/Xml/Request/AddressBookQueryReportTest.php
+++ b/tests/Sabre/CardDAV/Xml/Request/AddressBookQueryReportTest.php
@@ -84,10 +84,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeBadTest() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>
@@ -234,10 +232,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeBadMatchType() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>
@@ -258,10 +254,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeBadMatchType2() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>
@@ -280,10 +274,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeDoubleFilter() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0"?>

--- a/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
@@ -33,10 +33,8 @@ class AbstractDigestTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception
-     */
     function testCheckBadGetUserInfoResponse2() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $header = 'username=array, realm=myRealm, nonce=12345, uri=/, response=HASH, opaque=1, qop=auth, nc=1, cnonce=1';
         $request = HTTP\Sapi::createFromServerArray([

--- a/tests/Sabre/DAV/Auth/Backend/FileTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/FileTest.php
@@ -17,10 +17,8 @@ class FileTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception
-     */
     function testLoadFileBroken() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         file_put_contents(SABRE_TEMPDIR . '/backend', 'user:realm:hash');
         $file = new File(SABRE_TEMPDIR . '/backend');

--- a/tests/Sabre/DAV/Auth/PluginTest.php
+++ b/tests/Sabre/DAV/Auth/PluginTest.php
@@ -14,7 +14,7 @@ class PluginTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue($plugin instanceof Plugin);
         $fakeServer->addPlugin($plugin);
         $this->assertEquals($plugin, $fakeServer->getPlugin('auth'));
-        $this->assertInternalType('array', $plugin->getPluginInfo());
+        $this->assertIsArray($plugin->getPluginInfo());
 
     }
 
@@ -34,9 +34,9 @@ class PluginTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testInit
-     * @expectedException Sabre\DAV\Exception\NotAuthenticated
      */
     function testAuthenticateFail() {
+        $this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 
         $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
         $backend = new Backend\Mock();
@@ -90,9 +90,9 @@ class PluginTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testInit
-     * @expectedException Sabre\DAV\Exception
      */
     function testNoAuthBackend() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
 
@@ -103,9 +103,9 @@ class PluginTest extends \PHPUnit\Framework\TestCase {
     }
     /**
      * @depends testInit
-     * @expectedException Sabre\DAV\Exception
      */
     function testInvalidCheckResponse() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
         $backend = new Backend\Mock();

--- a/tests/Sabre/DAV/BasicNodeTest.php
+++ b/tests/Sabre/DAV/BasicNodeTest.php
@@ -4,20 +4,16 @@ namespace Sabre\DAV;
 
 class BasicNodeTest extends \PHPUnit\Framework\TestCase {
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testPut() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $file = new FileMock();
         $file->put('hi');
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testGet() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $file = new FileMock();
         $file->get();
@@ -46,20 +42,16 @@ class BasicNodeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testDelete() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $file = new FileMock();
         $file->delete();
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testSetName() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $file = new FileMock();
         $file->setName('hi');
@@ -98,30 +90,24 @@ class BasicNodeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\NotFound
-     */
     function testGetChild404() {
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
         $dir = new DirectoryMock();
         $file = $dir->getChild('blabla');
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testCreateFile() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $dir = new DirectoryMock();
         $dir->createFile('hello', 'data');
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
-     */
     function testCreateDirectory() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $dir = new DirectoryMock();
         $dir->createDirectory('hello');
@@ -149,10 +135,10 @@ class BasicNodeTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception
      * @depends testSimpleDirectoryConstruct
      */
     function testSimpleDirectoryBadParam() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $dir = new SimpleCollection('simpledir', ['string shouldn\'t be here']);
 
@@ -198,9 +184,9 @@ class BasicNodeTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testSimpleDirectoryConstruct
-     * @expectedException Sabre\DAV\Exception\NotFound
      */
     function testSimpleDirectoryGetChild404() {
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
         $dir = new SimpleCollection('simpledir');
         $dir->getChild('blabla');

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use InvalidArgumentException;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 
@@ -26,10 +27,8 @@ class ClientTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testConstructNoBaseUri() {
+        $this->expectException(InvalidArgumentException::class);
 
         $client = new ClientMock([]);
 
@@ -148,10 +147,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\HTTP\ClientHttpException
-     */
     function testPropFindError() {
+        $this->expectException(\Sabre\HTTP\ClientHttpException::class);
 
         $client = new ClientMock([
             'baseUri' => '/',
@@ -237,9 +234,9 @@ XML;
 
     /**
      * @depends testPropPatch
-     * @expectedException \Sabre\HTTP\ClientHttpException
      */
     function testPropPatchHTTPError() {
+        $this->expectException(\Sabre\HTTP\ClientHttpException::class);
 
         $client = new ClientMock([
             'baseUri' => '/',
@@ -252,9 +249,9 @@ XML;
 
     /**
      * @depends testPropPatch
-     * @expectedException Sabre\HTTP\ClientException
      */
     function testPropPatchMultiStatusError() {
+        $this->expectException(\Sabre\HTTP\ClientException::class);
 
         $client = new ClientMock([
             'baseUri' => '/',

--- a/tests/Sabre/DAV/FSExt/DirectoryTest.php
+++ b/tests/Sabre/DAV/FSExt/DirectoryTest.php
@@ -17,10 +17,8 @@ class DirectoryTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testChildExistDot() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $dir = $this->create();
         $dir->childExists('..');

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -985,10 +985,8 @@ class PluginTest extends DAV\AbstractServer {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testGetTimeoutHeaderInvalid() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $request = HTTP\Sapi::createFromServerArray([
             'HTTP_TIMEOUT' => 'yourmom',

--- a/tests/Sabre/DAV/Mock/Collection.php
+++ b/tests/Sabre/DAV/Mock/Collection.php
@@ -30,10 +30,10 @@ class Collection extends DAV\Collection {
      *
      * @param string $name
      * @param array $children
-     * @param Collection $parent
+     * @param ?Collection $parent
      * @return void
      */
-    function __construct($name, array $children = [], Collection $parent = null) {
+    function __construct($name, array $children = [], ?Collection $parent = null) {
 
         $this->name = $name;
         foreach ($children as $key => $value) {

--- a/tests/Sabre/DAV/Mock/File.php
+++ b/tests/Sabre/DAV/Mock/File.php
@@ -25,11 +25,11 @@ class File extends DAV\File {
      *
      * @param string $name
      * @param resource $contents
-     * @param Collection $parent
+     * @param ?Collection $parent
      * @param int $lastModified
      * @return void
      */
-    function __construct($name, $contents, Collection $parent = null, $lastModified = -1) {
+    function __construct($name, $contents, ?Collection $parent = null, $lastModified = -1) {
 
         $this->name = $name;
         $this->put($contents);

--- a/tests/Sabre/DAV/MockLogger.php
+++ b/tests/Sabre/DAV/MockLogger.php
@@ -24,7 +24,7 @@ class MockLogger extends AbstractLogger {
      * @param array $context
      * @return null
      */
-    function log($level, $message, array $context = []) {
+    function log($level, $message, array $context = []): void {
 
         $this->logs[] = [
             $level,

--- a/tests/Sabre/DAV/PropPatchTest.php
+++ b/tests/Sabre/DAV/PropPatchTest.php
@@ -217,10 +217,8 @@ class PropPatchTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     */
     function testHandleSingleBrokenResult() {
+        $this->expectException(\UnexpectedValueException::class);
 
         $propPatch = new PropPatch([
             '{DAV:}a' => 'foo',
@@ -331,10 +329,8 @@ class PropPatchTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     */
     function testHandleMultiValueBroken() {
+        $this->expectException(\UnexpectedValueException::class);
 
         $propPatch = new PropPatch([
             '{DAV:}a' => 'foo',

--- a/tests/Sabre/DAV/ServerPreconditionTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionTest.php
@@ -8,10 +8,8 @@ require_once 'Sabre/HTTP/ResponseMock.php';
 
 class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase {
 
-    /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
-     */
     function testIfMatchNoNode() {
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
@@ -33,10 +31,8 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
-     */
     function testIfMatchWrongEtag() {
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
@@ -97,10 +93,8 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
-     */
     function testIfNoneMatchHasNode() {
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
@@ -134,10 +128,8 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
-     */
     function testIfNoneMatchCorrectEtag() {
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
@@ -147,10 +139,8 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
-     */
     function testIfNoneMatchCorrectEtagMultiple() {
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
@@ -286,10 +276,8 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase {
     }
 
 
-    /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
-     */
     function testIfUnmodifiedSinceModified() {
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -149,7 +149,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
             $response->getHeaders()
         );
 
-        $this->assertEquals('st c', $response->getBodyAsString());
+        $this->assertEquals('onte', $response->getBodyAsString());
 
     }
 

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -17,10 +17,8 @@ class ServerSimpleTest extends AbstractServer{
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception
-     */
     function testConstructIncorrectObj() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $nodes = [
             new SimpleCollection('hello'),
@@ -31,10 +29,8 @@ class ServerSimpleTest extends AbstractServer{
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception
-     */
     function testConstructInvalidArg() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $server = new Server(1);
 
@@ -212,10 +208,8 @@ class ServerSimpleTest extends AbstractServer{
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testCalculateUriBreakout() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $uri = '/path1/';
 
@@ -343,9 +337,9 @@ class ServerSimpleTest extends AbstractServer{
 
     /**
      * @depends testGuessBaseUri
-     * @expectedException \Sabre\DAV\Exception
      */
     function testGuessBaseUriBadConfig() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $serverVars = [
             'REQUEST_URI' => '/index.php/root/heyyy',

--- a/tests/Sabre/DAV/Sharing/PluginTest.php
+++ b/tests/Sabre/DAV/Sharing/PluginTest.php
@@ -56,7 +56,7 @@ class PluginTest extends \Sabre\DAVServerTest {
     function testGetPluginInfo() {
 
         $result = $this->sharingPlugin->getPluginInfo();
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEquals('sharing', $result['name']);
 
     }
@@ -81,7 +81,7 @@ class PluginTest extends \Sabre\DAVServerTest {
         $this->assertNull(
             $this->sharingPlugin->htmlActionsPanel($node, $html, 'shareable')
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Share this resource',
             $html
         );
@@ -123,10 +123,8 @@ class PluginTest extends \Sabre\DAVServerTest {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testBrowserPostActionNoHref() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $this->sharingPlugin->browserPostAction(
             'shareable',
@@ -138,10 +136,8 @@ class PluginTest extends \Sabre\DAVServerTest {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testBrowserPostActionNoAccess() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $this->sharingPlugin->browserPostAction(
             'shareable',
@@ -154,10 +150,8 @@ class PluginTest extends \Sabre\DAVServerTest {
     }
 
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testBrowserPostActionBadAccess() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $this->sharingPlugin->browserPostAction(
             'shareable',
@@ -170,10 +164,8 @@ class PluginTest extends \Sabre\DAVServerTest {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testBrowserPostActionAccessDenied() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $this->aclPlugin->setDefaultAcl([]);
         $this->sharingPlugin->browserPostAction(

--- a/tests/Sabre/DAV/StringUtilTest.php
+++ b/tests/Sabre/DAV/StringUtilTest.php
@@ -71,20 +71,16 @@ class StringUtilTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testBadCollation() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         StringUtil::textMatch('foobar', 'foo', 'blabla', 'contains');
 
     }
 
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testBadMatchType() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         StringUtil::textMatch('foobar', 'foo', 'i;octet', 'booh');
 

--- a/tests/Sabre/DAV/Xml/Element/PropTest.php
+++ b/tests/Sabre/DAV/Xml/Element/PropTest.php
@@ -97,10 +97,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     function testDeserializeCustomBad() {
+        $this->expectException(\LogicException::class);
 
         $input = <<<XML
 <?xml version="1.0"?>
@@ -119,10 +117,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     function testDeserializeCustomBadObj() {
+        $this->expectException(\LogicException::class);
 
         $input = <<<XML
 <?xml version="1.0"?>
@@ -146,7 +142,7 @@ XML;
         $elementMap['{DAV:}root'] = 'Sabre\DAV\Xml\Element\Prop';
 
         $result = $this->parse($input, $elementMap);
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEquals($expected, $result['value']);
 
     }

--- a/tests/Sabre/DAV/Xml/Element/ResponseTest.php
+++ b/tests/Sabre/DAV/Xml/Element/ResponseTest.php
@@ -164,9 +164,9 @@ class ResponseTest extends DAV\Xml\XmlTest {
 
     /**
      * @depends testSerialize
-     * @expectedException \InvalidArgumentException
      */
     function testSerializeBreak() {
+        $this->expectException(\InvalidArgumentException::class);
 
         $innerProps = [
             200 => [

--- a/tests/Sabre/DAV/Xml/Element/ShareeTest.php
+++ b/tests/Sabre/DAV/Xml/Element/ShareeTest.php
@@ -7,10 +7,8 @@ use Sabre\DAV\Xml\XmlTest;
 
 class ShareeTest extends XmlTest {
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     function testShareeUnknownPropertyInConstructor() {
+        $this->expectException(\InvalidArgumentException::class);
 
         new Sharee(['foo' => 'bar']);
 
@@ -49,10 +47,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeNoHref() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0" encoding="utf-8" ?>
@@ -74,10 +70,8 @@ XML;
     }
 
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeNoShareeAccess() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = <<<XML
 <?xml version="1.0" encoding="utf-8" ?>

--- a/tests/Sabre/DAV/Xml/Property/ShareAccessTest.php
+++ b/tests/Sabre/DAV/Xml/Property/ShareAccessTest.php
@@ -100,10 +100,8 @@ XML;
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeInvalid() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $input = <<<XML
 <?xml version="1.0"?>

--- a/tests/Sabre/DAV/Xml/Request/SyncCollectionTest.php
+++ b/tests/Sabre/DAV/Xml/Request/SyncCollectionTest.php
@@ -76,10 +76,8 @@ class SyncCollectionTest extends XmlTest {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\BadRequest
-     */
     function testDeserializeMissingElem() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = '<?xml version="1.0"?>
 <d:sync-collection xmlns:d="DAV:">

--- a/tests/Sabre/DAVACL/ACLMethodTest.php
+++ b/tests/Sabre/DAVACL/ACLMethodTest.php
@@ -7,10 +7,8 @@ use Sabre\HTTP;
 
 class ACLMethodTest extends \PHPUnit\Framework\TestCase {
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testCallback() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $acl = new Plugin();
         $server = new DAV\Server();
@@ -21,11 +19,8 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
-     */
     function testNotSupportedByNode() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $tree = [
             new DAV\SimpleCollection('test'),
@@ -65,10 +60,8 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NotRecognizedPrincipal
-     */
     function testUnrecognizedPrincipal() {
+        $this->expectException(\Sabre\DAVACL\Exception\NotRecognizedPrincipal::class);
 
         $tree = [
             new MockACLNode('test', []),
@@ -91,10 +84,8 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NotRecognizedPrincipal
-     */
     function testUnrecognizedPrincipal2() {
+        $this->expectException(\Sabre\DAVACL\Exception\NotRecognizedPrincipal::class);
 
         $tree = [
             new MockACLNode('test', []),
@@ -120,10 +111,8 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NotSupportedPrivilege
-     */
     function testUnknownPrivilege() {
+        $this->expectException(\Sabre\DAVACL\Exception\NotSupportedPrivilege::class);
 
         $tree = [
             new MockACLNode('test', []),
@@ -146,10 +135,8 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NoAbstract
-     */
     function testAbstractPrivilege() {
+        $this->expectException(\Sabre\DAVACL\Exception\NoAbstract::class);
 
         $tree = [
             new MockACLNode('test', []),
@@ -175,10 +162,8 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\AceConflict
-     */
     function testUpdateProtectedPrivilege() {
+        $this->expectException(\Sabre\DAVACL\Exception\AceConflict::class);
 
         $oldACL = [
             [
@@ -209,10 +194,8 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\AceConflict
-     */
     function testUpdateProtectedPrivilege2() {
+        $this->expectException(\Sabre\DAVACL\Exception\AceConflict::class);
 
         $oldACL = [
             [
@@ -243,10 +226,8 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\AceConflict
-     */
     function testUpdateProtectedPrivilege3() {
+        $this->expectException(\Sabre\DAVACL\Exception\AceConflict::class);
 
         $oldACL = [
             [

--- a/tests/Sabre/DAVACL/BlockAccessTest.php
+++ b/tests/Sabre/DAVACL/BlockAccessTest.php
@@ -35,10 +35,8 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testGet() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->httpRequest->setMethod('GET');
         $this->server->httpRequest->setUrl('/testdir');
@@ -57,10 +55,8 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testHEAD() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->httpRequest->setMethod('HEAD');
         $this->server->httpRequest->setUrl('/testdir');
@@ -69,10 +65,8 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testOPTIONS() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->httpRequest->setMethod('OPTIONS');
         $this->server->httpRequest->setUrl('/testdir');
@@ -81,10 +75,8 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testPUT() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->httpRequest->setMethod('PUT');
         $this->server->httpRequest->setUrl('/testdir');
@@ -93,10 +85,8 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testPROPPATCH() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->httpRequest->setMethod('PROPPATCH');
         $this->server->httpRequest->setUrl('/testdir');
@@ -105,10 +95,8 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testCOPY() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->httpRequest->setMethod('COPY');
         $this->server->httpRequest->setUrl('/testdir');
@@ -117,10 +105,8 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testMOVE() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->httpRequest->setMethod('MOVE');
         $this->server->httpRequest->setUrl('/testdir');
@@ -129,10 +115,8 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testACL() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->httpRequest->setMethod('ACL');
         $this->server->httpRequest->setUrl('/testdir');
@@ -141,10 +125,8 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testLOCK() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->httpRequest->setMethod('LOCK');
         $this->server->httpRequest->setUrl('/testdir');
@@ -153,19 +135,15 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testBeforeBind() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->emit('beforeBind', ['testdir/file']);
 
     }
 
-    /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
-     */
     function testBeforeUnbind() {
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
 
         $this->server->emit('beforeUnbind', ['testdir']);
 

--- a/tests/Sabre/DAVACL/FS/FileTest.php
+++ b/tests/Sabre/DAVACL/FS/FileTest.php
@@ -53,10 +53,8 @@ class FileTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetAcl() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $this->sut->setACL([]);
 

--- a/tests/Sabre/DAVACL/FS/HomeCollectionTest.php
+++ b/tests/Sabre/DAVACL/FS/HomeCollectionTest.php
@@ -96,10 +96,8 @@ class HomeCollectionTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetAcl() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $this->sut->setACL([]);
 

--- a/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
@@ -73,10 +73,8 @@ class PluginUpdatePropertiesTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception
-     */
     function testSetBadValue() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $tree = [
             new MockPrincipal('foo', 'foo'),

--- a/tests/Sabre/DAVACL/PrincipalCollectionTest.php
+++ b/tests/Sabre/DAVACL/PrincipalCollectionTest.php
@@ -33,9 +33,9 @@ class PrincipalCollectionTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testBasic
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
      */
     function testGetChildrenDisable() {
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
         $backend = new PrincipalBackend\Mock();
         $pc = new PrincipalCollection($backend);

--- a/tests/Sabre/DAVACL/PrincipalTest.php
+++ b/tests/Sabre/DAVACL/PrincipalTest.php
@@ -15,10 +15,8 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception
-     */
     function testConstructNoUri() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $principalBackend = new PrincipalBackend\Mock();
         $principal = new Principal($principalBackend, []);
@@ -186,10 +184,8 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
-     */
     function testSetACl() {
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
         $principalBackend = new PrincipalBackend\Mock();
         $principal = new Principal($principalBackend, ['uri' => 'principals/admin']);

--- a/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
@@ -187,10 +187,8 @@ class ACLTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testUnserializeNoPrincipal() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $source = '<?xml version="1.0"?>
 <d:root xmlns:d="DAV:">
@@ -276,10 +274,8 @@ class ACLTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\NotImplemented
-     */
     function testUnserializeDeny() {
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
 
         $source = '<?xml version="1.0"?>
 <d:root xmlns:d="DAV:">

--- a/tests/Sabre/DAVACL/Xml/Property/PrincipalTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/PrincipalTest.php
@@ -27,9 +27,9 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testSimple
-     * @expectedException Sabre\DAV\Exception
      */
     function testNoHref() {
+        $this->expectException(\Sabre\DAV\Exception::class);
 
         $principal = new Principal(Principal::HREF);
 
@@ -120,10 +120,8 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
-     */
     function testUnserializeUnknown() {
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
         $xml = '<?xml version="1.0"?>
 <d:principal xmlns:d="DAV:">' .

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+error_reporting(E_ALL ^ E_DEPRECATED);
+
 set_include_path(__DIR__ . '/../lib/' . PATH_SEPARATOR . __DIR__ . PATH_SEPARATOR . get_include_path());
 
 $autoLoader = include __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
- Pin dependencies to BC deps. Contains various fixes for PHP versions
- Fix tests so we have some confidence in making changes
- Loosen psr/log to allow v2 and v3

```
$ ./vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.

....SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS   61 / 1584 (  3%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS..................  122 / 1584 (  7%)
.............................................................  183 / 1584 ( 11%)
.............................................................  244 / 1584 ( 15%)
.............................................................  305 / 1584 ( 19%)
.............................................................  366 / 1584 ( 23%)
.............................................................  427 / 1584 ( 26%)
.............................................................  488 / 1584 ( 30%)
.............................................................  549 / 1584 ( 34%)
.............................................................  610 / 1584 ( 38%)
..........................................................SSS  671 / 1584 ( 42%)
SSSSSSSSSSSSSSSSSSSSSSSSS....................................  732 / 1584 ( 46%)
.............................................................  793 / 1584 ( 50%)
.........................SSSS................................  854 / 1584 ( 53%)
.............................................................  915 / 1584 ( 57%)
.............................................................  976 / 1584 ( 61%)
..................SSSSSSSSSSSSSSSS........................... 1037 / 1584 ( 65%)
............................................................. 1098 / 1584 ( 69%)
..........SSSSSSSSSSSSSSSSSS................................. 1159 / 1584 ( 73%)
............................................................. 1220 / 1584 ( 77%)
............................................................. 1281 / 1584 ( 80%)
............................................................. 1342 / 1584 ( 84%)
............................................................. 1403 / 1584 ( 88%)
............................................................. 1464 / 1584 ( 92%)
............SSSSSSSSSSSSSSSSSSSSSS........................... 1525 / 1584 ( 96%)
...........................................................   1584 / 1584 (100%)

Time: 00:01.241, Memory: 46.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 1584, Assertions: 2802, Skipped: 188.
```